### PR TITLE
Fix rapid event tap recreation

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -167,7 +167,6 @@ pub enum Message {
     FileSearchClear,
     SetFileSearchSender(tokio::sync::watch::Sender<(String, Vec<String>)>),
     DebouncedSearch(Id),
-    CheckEventTap,
     ThemeModeChanged(bool),
     SimulatePaste(i32),
 }

--- a/src/app/tile.rs
+++ b/src/app/tile.rs
@@ -269,7 +269,6 @@ impl Tile {
             Subscription::run(reload_events),
             Subscription::run(handle_version_and_rankings),
             Subscription::run(handle_theme_mode),
-            Subscription::run(check_event_tap),
             Subscription::run(handle_clipboard_history),
             Subscription::run(handle_file_search),
             window::close_events().map(Message::HideWindow),
@@ -800,15 +799,6 @@ fn reload_events() -> impl futures::Stream<Item = Message> {
         loop {
             output.send(Message::UpdateEvents).await.ok();
             tokio::time::sleep(Duration::from_mins(2)).await;
-        }
-    })
-}
-
-fn check_event_tap() -> impl futures::Stream<Item = Message> {
-    stream::channel(100, async |mut output| {
-        loop {
-            tokio::time::sleep(Duration::from_secs(5)).await;
-            output.send(Message::CheckEventTap).await.ok();
         }
     })
 }

--- a/src/app/tile/update.rs
+++ b/src/app/tile/update.rs
@@ -1089,18 +1089,6 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
             Task::none()
         }
 
-        Message::CheckEventTap => {
-            info!("Re-creating global event tap");
-            if let Some(ref sender) = tile.sender {
-                tile.hotkeys.handle = None;
-                match global_handler(sender.clone(), tile.hotkeys.all_hotkeys()) {
-                    Ok(handle) => tile.hotkeys.handle = Some(handle),
-                    Err(e) => log::error!("Failed to re-create event tap: {e}"),
-                }
-            }
-            Task::none()
-        }
-
         Message::SimulatePaste(pid) => {
             crate::platform::simulate_paste(pid);
             Task::none()


### PR DESCRIPTION
Fixes #279 

This removes the rapid recreation of the event tap which I believe is the source of this issue.