### PR TITLE
Settings UI Redesign

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -126,7 +126,7 @@ pub enum Editable<T> {
 #[derive(Debug, Clone)]
 pub enum Message {
     UriReceived(String),
-    WriteConfig(bool),
+    WriteConfig,
     SaveRanking,
     ToggleAutoStartup(bool),
     LoadRanking,

--- a/src/app.rs
+++ b/src/app.rs
@@ -31,14 +31,14 @@ pub const FILE_SEARCH_BATCH_SIZE: u32 = 10;
 /// The rustcast descriptor name to be put for all rustcast commands
 pub const RUSTCAST_DESC_NAME: &str = "Utility";
 
-/// The different pages that rustcast can have / has
+/// The different pages that rustcast can have / has within the launcher
+/// Settings is notably missing since this opens as a new window outside the launcher
 #[derive(Debug, Clone, PartialEq)]
 pub enum Page {
     Main,
     FileSearch,
     ClipboardHistory,
     EmojiSearch,
-    Settings,
 }
 
 /// The settings panel tabs
@@ -94,7 +94,6 @@ impl std::fmt::Display for Page {
             Page::FileSearch => "File search",
             Page::EmojiSearch => "Emoji search",
             Page::ClipboardHistory => "Clipboard history",
-            Page::Settings => "Settings",
         })
     }
 }
@@ -136,7 +135,6 @@ pub enum Message {
     ResizeWindow(Id, f32),
     OpenWindow,
     OpenResult(u32),
-    OpenToSettings,
     SearchQueryChanged(String, Id),
     KeyPressed(Shortcut),
     FocusTextInput(Move),
@@ -169,6 +167,8 @@ pub enum Message {
     DebouncedSearch(Id),
     ThemeModeChanged(bool),
     SimulatePaste(i32),
+    OpenSettingsWindow,
+    SettingsWindowOpened(window::Id),
 }
 
 #[derive(Debug, Clone)]
@@ -224,6 +224,23 @@ pub fn default_settings() -> Settings {
             width: WINDOW_WIDTH,
             height: DEFAULT_WINDOW_HEIGHT,
         },
+        ..Default::default()
+    }
+}
+
+pub fn settings_window_settings() -> window::Settings {
+    Settings {
+        resizable: false,
+        decorations: true,
+        minimizable: false,
+        level: window::Level::AlwaysOnTop,
+        transparent: false,
+        blur: false,
+        size: iced::Size {
+            width: 600.,
+            height: 478.,
+        },
+        position: window::Position::Centered,
         ..Default::default()
     }
 }
@@ -287,7 +304,7 @@ impl ToApps for HashMap<String, String> {
 impl DebouncePolicy for Page {
     fn debounce_delay(&self, config: &Config) -> Option<Duration> {
         match self {
-            Page::Main | Page::ClipboardHistory | Page::Settings => None,
+            Page::Main | Page::ClipboardHistory => None,
             Page::FileSearch | Page::EmojiSearch => {
                 Some(Duration::from_millis(config.debounce_delay))
             }
@@ -306,7 +323,6 @@ mod tests {
         assert_eq!(Page::FileSearch.to_string(), "File search");
         assert_eq!(Page::ClipboardHistory.to_string(), "Clipboard history");
         assert_eq!(Page::EmojiSearch.to_string(), "Emoji search");
-        assert_eq!(Page::Settings.to_string(), "Settings");
     }
 
     #[test]
@@ -318,7 +334,6 @@ mod tests {
 
         assert_eq!(Page::Main.debounce_delay(&config), None);
         assert_eq!(Page::ClipboardHistory.debounce_delay(&config), None);
-        assert_eq!(Page::Settings.debounce_delay(&config), None);
         assert_eq!(
             Page::FileSearch.debounce_delay(&config),
             Some(Duration::from_millis(123))

--- a/src/app.rs
+++ b/src/app.rs
@@ -237,8 +237,8 @@ pub fn settings_window_settings() -> window::Settings {
         transparent: false,
         blur: false,
         size: iced::Size {
-            width: 800.,
-            height: 478.,
+            width: 900.,
+            height: 600.,
         },
         position: window::Position::Centered,
         ..Default::default()

--- a/src/app.rs
+++ b/src/app.rs
@@ -237,7 +237,7 @@ pub fn settings_window_settings() -> window::Settings {
         transparent: false,
         blur: false,
         size: iced::Size {
-            width: 600.,
+            width: 800.,
             height: 478.,
         },
         position: window::Position::Centered,

--- a/src/app/apps.rs
+++ b/src/app/apps.rs
@@ -128,7 +128,7 @@ impl App {
             },
             App {
                 ranking: 0,
-                open_command: AppCommand::Message(Message::SwitchToPage(Page::Settings)),
+                open_command: AppCommand::Message(Message::OpenSettingsWindow),
                 desc: RUSTCAST_DESC_NAME.to_string(),
                 icons: icons.clone(),
                 display_name: "Open RustCast Preferences".to_string(),

--- a/src/app/menubar.rs
+++ b/src/app/menubar.rs
@@ -128,7 +128,10 @@ fn init_event_handler(sender: ExtSender, shortcut: Shortcut) {
             }
             "open_preferences" => {
                 runtime.spawn(async move {
-                    sender.clone().try_send(Message::OpenToSettings).unwrap();
+                    sender
+                        .clone()
+                        .try_send(Message::OpenSettingsWindow)
+                        .unwrap();
                 });
             }
             "open_github_page" => {

--- a/src/app/pages/settings.rs
+++ b/src/app/pages/settings.rs
@@ -745,6 +745,7 @@ fn section_header_with_reset(
 ) -> Element<'static, Message> {
     Row::from_iter([
         settings_hint_text(theme.clone(), label, None::<String>),
+        Space::new().width(Length::Fill).into(),
         reset_button(theme, field),
     ])
     .align_y(Alignment::Center)

--- a/src/app/pages/settings.rs
+++ b/src/app/pages/settings.rs
@@ -5,11 +5,14 @@ use std::collections::HashMap;
 use iced::Border;
 use iced::border::Radius;
 use iced::widget::Container;
+use iced::widget::Scrollable;
 use iced::widget::Slider;
 use iced::widget::Space;
 use iced::widget::TextInput;
 use iced::widget::button;
 use iced::widget::radio;
+use iced::widget::scrollable::Direction;
+use iced::widget::scrollable::Scrollbar;
 use iced::widget::text_input;
 use iced::widget::toggler;
 
@@ -92,12 +95,15 @@ pub fn settings_page(config: Config, settings_tab: SettingsTab) -> Element<'stat
         .into(),
     ]);
 
-    let contents_container = Container::new(contents_column)
-        .style(move |_| settings_contents_container_style(&theme))
-        .height(Length::Fill)
-        .width(Length::Fill)
-        .padding(12)
-        .align_x(Alignment::Center);
+    let contents_container = Container::new(Scrollable::with_direction(
+        contents_column,
+        Direction::Vertical(Scrollbar::hidden()),
+    ))
+    .style(move |_| settings_contents_container_style(&theme))
+    .height(Length::Fill)
+    .width(Length::Fill)
+    .padding(12)
+    .align_x(Alignment::Center);
 
     let items = Row::from_iter([tabs_container.into(), contents_container.into()]);
 
@@ -244,7 +250,7 @@ fn general_tab(config: Box<Config>, theme: crate::config::Theme) -> Column<'stat
         settings_item_row([
             settings_hint_text(
                 theme.clone(),
-                "Set the debounce time",
+                "Set the debounce time (ms)",
                 Some("File search response time"),
             ),
             Space::new().width(Length::Fill).into(),
@@ -337,56 +343,49 @@ fn general_tab(config: Box<Config>, theme: crate::config::Theme) -> Column<'stat
     );
 
     let theme_clone = theme.clone();
-    let auto_suggest = settings_row_with_reset(
-        settings_item_column([
-            settings_hint_text(
-                theme.clone(),
-                "Suggestions on open",
-                Some("What an empty query should show"),
-            ),
-            settings_item_row([
-                radio(
-                    "Favourites",
-                    MainPage::Favourites,
-                    Some(config.main_page),
-                    |page| Message::SetConfig(SetConfigFields::SetPage(page)),
-                )
-                .style({
-                    let theme_clone = theme_clone.clone();
-                    move |_, _| settings_radio_button_style(&theme_clone.clone())
-                })
-                .into(),
-                radio(
-                    "Frequents",
-                    MainPage::FrequentlyUsed,
-                    Some(config.main_page),
-                    |page| Message::SetConfig(SetConfigFields::SetPage(page)),
-                )
-                .style({
-                    let theme_clone = theme_clone.clone();
-                    move |_, _| settings_radio_button_style(&theme_clone.clone())
-                })
-                .into(),
-                radio("Events", MainPage::Events, Some(config.main_page), |page| {
-                    Message::SetConfig(SetConfigFields::SetPage(page))
-                })
-                .style({
-                    let theme_clone = theme_clone.clone();
-                    move |_, _| settings_radio_button_style(&theme_clone.clone())
-                })
-                .into(),
-                radio("Nothing", MainPage::Blank, Some(config.main_page), |page| {
-                    Message::SetConfig(SetConfigFields::SetPage(page))
-                })
-                .style(move |_, _| settings_radio_button_style(&theme_clone.clone()))
-                .into(),
-            ])
-            .spacing(30)
+    let auto_suggest = settings_row_without_reset(settings_item_row([
+        settings_hint_text(theme.clone(), "Suggestions on open", None::<String>),
+        Space::new().width(Length::Fill).into(),
+        settings_item_row([
+            radio(
+                "Favourites",
+                MainPage::Favourites,
+                Some(config.main_page),
+                |page| Message::SetConfig(SetConfigFields::SetPage(page)),
+            )
+            .style({
+                let theme_clone = theme_clone.clone();
+                move |_, _| settings_radio_button_style(&theme_clone.clone())
+            })
             .into(),
-        ]),
-        ResetField::MainPage,
-        theme.clone(),
-    );
+            radio(
+                "Frequents",
+                MainPage::FrequentlyUsed,
+                Some(config.main_page),
+                |page| Message::SetConfig(SetConfigFields::SetPage(page)),
+            )
+            .style({
+                let theme_clone = theme_clone.clone();
+                move |_, _| settings_radio_button_style(&theme_clone.clone())
+            })
+            .into(),
+            radio("Events", MainPage::Events, Some(config.main_page), |page| {
+                Message::SetConfig(SetConfigFields::SetPage(page))
+            })
+            .style({
+                let theme_clone = theme_clone.clone();
+                move |_, _| settings_radio_button_style(&theme_clone.clone())
+            })
+            .into(),
+            radio("Nothing", MainPage::Blank, Some(config.main_page), |page| {
+                Message::SetConfig(SetConfigFields::SetPage(page))
+            })
+            .style(move |_, _| settings_radio_button_style(&theme_clone.clone()))
+            .into(),
+        ])
+        .spacing(30)
+        .into(),
+    ]));
 
     Column::from_iter([
         hotkey,
@@ -407,8 +406,9 @@ fn general_tab(config: Box<Config>, theme: crate::config::Theme) -> Column<'stat
 
 fn appearance_tab(config: Box<Config>, theme: crate::config::Theme) -> Column<'static, Message> {
     let theme_clone = theme.clone();
-    let theme_mode_setting = settings_row_without_reset(settings_item_column([
+    let theme_mode_setting = settings_row_without_reset(settings_item_row([
         settings_hint_text(theme.clone(), "Theme mode", None::<String>),
+        Space::new().width(Length::Fill).into(),
         settings_item_row([
             radio(
                 "Dark",
@@ -841,14 +841,6 @@ fn settings_hint_text(
     }
 
     container(content).into()
-}
-
-fn settings_item_column(
-    elems: impl IntoIterator<Item = Element<'static, Message>>,
-) -> Column<'static, Message> {
-    Column::from_iter(elems)
-        .spacing(SETTINGS_ITEM_COL_SPACING)
-        .padding(SETTINGS_ITEM_PADDING)
 }
 
 fn settings_item_row(

--- a/src/app/pages/settings.rs
+++ b/src/app/pages/settings.rs
@@ -47,6 +47,7 @@ use crate::{
 const SETTINGS_ITEM_PADDING: u16 = 4;
 const SETTINGS_ITEM_HEIGHT: u32 = 55;
 const SETTINGS_ITEM_COL_SPACING: u32 = 3;
+const SETTINGS_INPUT_WIDTH: f32 = 250.0;
 
 pub fn settings_page(config: Config, settings_tab: SettingsTab) -> Element<'static, Message> {
     let config = Box::new(config.clone());
@@ -73,7 +74,7 @@ pub fn settings_page(config: Config, settings_tab: SettingsTab) -> Element<'stat
     let tabs_container = Container::new(tabs_column)
         .style(move |_| settings_tabs_container_style(&theme_clone))
         .height(Length::Fill)
-        .width(Length::Fixed(250.0))
+        .width(Length::Fixed(SETTINGS_INPUT_WIDTH))
         .padding(12)
         .align_x(Alignment::Center);
 
@@ -173,8 +174,8 @@ fn general_tab(config: Box<Config>, theme: crate::config::Theme) -> Column<'stat
             Space::new().width(Length::Fill).into(),
             text_input("Toggle Hotkey", &config.toggle_hotkey)
                 .on_input(|input| Message::SetConfig(SetConfigFields::ToggleHotkey(input.clone())))
-                .on_submit(Message::WriteConfig(false))
-                .width(Length::Fixed(250.0))
+                .on_submit(Message::WriteConfig)
+                .width(Length::Fixed(SETTINGS_INPUT_WIDTH))
                 .style(move |_, _| settings_text_input_item_style(&theme_clone))
                 .into(),
         ]),
@@ -195,8 +196,8 @@ fn general_tab(config: Box<Config>, theme: crate::config::Theme) -> Column<'stat
                 .on_input(|input| {
                     Message::SetConfig(SetConfigFields::ClipboardHotkey(input.clone()))
                 })
-                .on_submit(Message::WriteConfig(false))
-                .width(Length::Fixed(250.0))
+                .on_submit(Message::WriteConfig)
+                .width(Length::Fixed(SETTINGS_INPUT_WIDTH))
                 .style(move |_, _| settings_text_input_item_style(&theme_clone))
                 .into(),
         ]),
@@ -215,8 +216,8 @@ fn general_tab(config: Box<Config>, theme: crate::config::Theme) -> Column<'stat
             Space::new().width(Length::Fill).into(),
             text_input("Set Placeholder", &config.placeholder)
                 .on_input(|input| Message::SetConfig(SetConfigFields::PlaceHolder(input.clone())))
-                .on_submit(Message::WriteConfig(false))
-                .width(Length::Fixed(250.0))
+                .on_submit(Message::WriteConfig)
+                .width(Length::Fixed(SETTINGS_INPUT_WIDTH))
                 .style(move |_, _| settings_text_input_item_style(&theme_clone))
                 .into(),
         ]),
@@ -235,8 +236,8 @@ fn general_tab(config: Box<Config>, theme: crate::config::Theme) -> Column<'stat
             Space::new().width(Length::Fill).into(),
             text_input("Set Search URL", &config.search_url)
                 .on_input(|input| Message::SetConfig(SetConfigFields::SearchUrl(input.clone())))
-                .on_submit(Message::WriteConfig(false))
-                .width(Length::Fixed(250.0))
+                .on_submit(Message::WriteConfig)
+                .width(Length::Fixed(SETTINGS_INPUT_WIDTH))
                 .style(move |_, _| settings_text_input_item_style(&theme_clone))
                 .into(),
         ]),
@@ -259,8 +260,8 @@ fn general_tab(config: Box<Config>, theme: crate::config::Theme) -> Column<'stat
                     let delay = input.parse::<u64>().unwrap_or(current_delay);
                     Message::SetConfig(SetConfigFields::DebounceDelay(delay))
                 })
-                .on_submit(Message::WriteConfig(false))
-                .width(Length::Fixed(250.0))
+                .on_submit(Message::WriteConfig)
+                .width(Length::Fixed(SETTINGS_INPUT_WIDTH))
                 .style(move |_, _| settings_text_input_item_style(&theme_clone))
                 .into(),
         ]),
@@ -312,7 +313,7 @@ fn general_tab(config: Box<Config>, theme: crate::config::Theme) -> Column<'stat
 
     let clipboard_history = settings_row_without_reset(
         Row::from_iter([
-            settings_hint_text(theme.clone(), "Enable Clipboard history", None::<String>),
+            settings_hint_text(theme.clone(), "Enable clipboard history", None::<String>),
             Space::new().width(Length::Fill).into(),
             toggler(config.clone().cbhist)
                 .style(move |_, status| settings_toggle_style(status))
@@ -474,7 +475,7 @@ fn appearance_tab(config: Box<Config>, theme: crate::config::Theme) -> Column<'s
         settings_hint_text(
             theme.clone(),
             "Clear on hide",
-            Some("If the query should be cleared when rustcast is hidden"),
+            Some("Clear query when rustcast is hidden"),
         ),
         Space::new().width(Length::Fill).into(),
         toggler(config.clone().buffer_rules.clear_on_hide)
@@ -516,7 +517,7 @@ fn appearance_tab(config: Box<Config>, theme: crate::config::Theme) -> Column<'s
     let theme_clone = theme.clone();
     let font_family = settings_row_with_reset(
         settings_item_row([
-            settings_hint_text(theme.clone(), "Set Font family", None::<String>),
+            settings_hint_text(theme.clone(), "Font family", None::<String>),
             Space::new().width(Length::Fill).into(),
             text_input(
                 "Font family",
@@ -527,8 +528,8 @@ fn appearance_tab(config: Box<Config>, theme: crate::config::Theme) -> Column<'s
                     input,
                 )))
             })
-            .on_submit(Message::WriteConfig(false))
-            .width(Length::Fixed(250.0))
+            .on_submit(Message::WriteConfig)
+            .width(Length::Fixed(SETTINGS_INPUT_WIDTH))
             .style(move |_, _| settings_text_input_item_style(&theme_clone))
             .into(),
         ]),
@@ -541,7 +542,7 @@ fn appearance_tab(config: Box<Config>, theme: crate::config::Theme) -> Column<'s
         settings_item_row([
             settings_hint_text(
                 theme.clone(),
-                "Set Event duration",
+                "Event duration",
                 Some("Minutes from now events should be displayed"),
             ),
             Space::new().width(Length::Fill).into(),
@@ -549,8 +550,8 @@ fn appearance_tab(config: Box<Config>, theme: crate::config::Theme) -> Column<'s
                 .on_input(move |input: String| {
                     Message::SetConfig(SetConfigFields::SetEventDuration(input))
                 })
-                .on_submit(Message::WriteConfig(false))
-                .width(Length::Fixed(250.0))
+                .on_submit(Message::WriteConfig)
+                .width(Length::Fixed(SETTINGS_INPUT_WIDTH))
                 .style(move |_, _| settings_text_input_item_style(&theme_clone))
                 .into(),
         ]),
@@ -623,7 +624,6 @@ fn appearance_tab(config: Box<Config>, theme: crate::config::Theme) -> Column<'s
                 .style(move |_, _| settings_slider_style(&theme_clone_3))
                 .width((WINDOW_WIDTH / 5.) * 4.)
                 .into(),
-                notice_item(theme.clone(), "Text colour in RGB format"),
             ])
             .spacing(7)
             .width(Length::Fill)
@@ -699,7 +699,6 @@ fn appearance_tab(config: Box<Config>, theme: crate::config::Theme) -> Column<'s
                 .style(move |_, _| settings_slider_style(&theme_clone_3))
                 .width((WINDOW_WIDTH / 5.) * 4.)
                 .into(),
-                notice_item(theme.clone(), "Background colour in RGB format"),
             ])
             .spacing(7)
             .width(Length::Fill)
@@ -785,7 +784,7 @@ fn savebutton(theme: Theme) -> Element<'static, Message> {
     )
     .style(move |_, _| settings_save_button_style(&theme))
     .width(Length::Fill)
-    .on_press(Message::WriteConfig(true))
+    .on_press(Message::WriteConfig)
     .into()
 }
 
@@ -972,7 +971,7 @@ fn text_input_cell(text: String, theme: &Theme, placeholder: &str) -> TextInput<
     text_input(placeholder, &text)
         .font(theme.font())
         .padding(5)
-        .on_submit(Message::WriteConfig(false))
+        .on_submit(Message::WriteConfig)
 }
 
 fn modes_item(modes: HashMap<String, String>, theme: &Theme) -> Element<'static, Message> {

--- a/src/app/pages/settings.rs
+++ b/src/app/pages/settings.rs
@@ -70,7 +70,7 @@ pub fn settings_page(config: Config, settings_tab: SettingsTab) -> Element<'stat
     let tabs_container = Container::new(tabs_column)
         .style(move |_| settings_tabs_container_style(&theme_clone))
         .height(Length::Fill)
-        .width(Length::Fixed(200.0))
+        .width(Length::Fixed(250.0))
         .padding(12)
         .align_x(Alignment::Center);
 
@@ -158,15 +158,19 @@ fn reset_button(theme: crate::config::Theme, field: ResetField) -> Element<'stat
 fn general_tab(config: Box<Config>, theme: crate::config::Theme) -> Column<'static, Message> {
     let theme_clone = theme.clone();
     let hotkey = settings_row_with_reset(
-        settings_item_column([
-            settings_hint_text(theme.clone(), "Toggle hotkey"),
+        settings_item_row([
+            settings_hint_text(
+                theme.clone(),
+                "Toggle hotkey",
+                Some("Use \"+\" as a seperator"),
+            ),
+            Space::new().width(Length::Fill).into(),
             text_input("Toggle Hotkey", &config.toggle_hotkey)
                 .on_input(|input| Message::SetConfig(SetConfigFields::ToggleHotkey(input.clone())))
                 .on_submit(Message::WriteConfig(false))
-                .width(Length::Fill)
+                .width(Length::Fixed(250.0))
                 .style(move |_, _| settings_text_input_item_style(&theme_clone))
                 .into(),
-            notice_item(theme.clone(), "Use \"+\" as a seperator"),
         ]),
         ResetField::ToggleHotkey,
         theme.clone(),
@@ -174,17 +178,21 @@ fn general_tab(config: Box<Config>, theme: crate::config::Theme) -> Column<'stat
 
     let theme_clone = theme.clone();
     let cb_hotkey = settings_row_with_reset(
-        settings_item_column([
-            settings_hint_text(theme.clone(), "Clipboard hotkey"),
+        settings_item_row([
+            settings_hint_text(
+                theme.clone(),
+                "Clipboard hotkey",
+                Some("Use \"+\" as a seperator"),
+            ),
+            Space::new().width(Length::Fill).into(),
             text_input("Clipboard Hotkey", &config.clipboard_hotkey)
                 .on_input(|input| {
                     Message::SetConfig(SetConfigFields::ClipboardHotkey(input.clone()))
                 })
                 .on_submit(Message::WriteConfig(false))
-                .width(Length::Fill)
+                .width(Length::Fixed(250.0))
                 .style(move |_, _| settings_text_input_item_style(&theme_clone))
                 .into(),
-            notice_item(theme.clone(), "Use \"+\" as a seperator"),
         ]),
         ResetField::ClipboardHotkey,
         theme.clone(),
@@ -192,15 +200,19 @@ fn general_tab(config: Box<Config>, theme: crate::config::Theme) -> Column<'stat
 
     let theme_clone = theme.clone();
     let placeholder_setting = settings_row_with_reset(
-        settings_item_column([
-            settings_hint_text(theme.clone(), "Set the rustcast placeholder"),
+        settings_item_row([
+            settings_hint_text(
+                theme.clone(),
+                "Set the rustcast placeholder",
+                Some("Welcome text on open"),
+            ),
+            Space::new().width(Length::Fill).into(),
             text_input("Set Placeholder", &config.placeholder)
                 .on_input(|input| Message::SetConfig(SetConfigFields::PlaceHolder(input.clone())))
                 .on_submit(Message::WriteConfig(false))
-                .width(Length::Fill)
+                .width(Length::Fixed(250.0))
                 .style(move |_, _| settings_text_input_item_style(&theme_clone))
                 .into(),
-            notice_item(theme.clone(), "What the text box shows when its empty"),
         ]),
         ResetField::Placeholder,
         theme.clone(),
@@ -208,15 +220,19 @@ fn general_tab(config: Box<Config>, theme: crate::config::Theme) -> Column<'stat
 
     let theme_clone = theme.clone();
     let search = settings_row_with_reset(
-        settings_item_column([
-            settings_hint_text(theme.clone(), "Set the search URL"),
+        settings_item_row([
+            settings_hint_text(
+                theme.clone(),
+                "Set the search URL",
+                Some("Search engine to use (%s = query)"),
+            ),
+            Space::new().width(Length::Fill).into(),
             text_input("Set Search URL", &config.search_url)
                 .on_input(|input| Message::SetConfig(SetConfigFields::SearchUrl(input.clone())))
                 .on_submit(Message::WriteConfig(false))
-                .width(Length::Fill)
+                .width(Length::Fixed(250.0))
                 .style(move |_, _| settings_text_input_item_style(&theme_clone))
                 .into(),
-            notice_item(theme.clone(), "Which search engine to use (%s = query)"),
         ]),
         ResetField::SearchUrl,
         theme.clone(),
@@ -225,134 +241,109 @@ fn general_tab(config: Box<Config>, theme: crate::config::Theme) -> Column<'stat
     let theme_clone = theme.clone();
     let current_delay = config.debounce_delay;
     let debounce = settings_row_with_reset(
-        settings_item_column([
-            settings_hint_text(theme.clone(), "Set the debounce time"),
+        settings_item_row([
+            settings_hint_text(
+                theme.clone(),
+                "Set the debounce time",
+                Some("File search response time"),
+            ),
+            Space::new().width(Length::Fill).into(),
             text_input("Set Debounce time (ms)", &config.debounce_delay.to_string())
                 .on_input(move |input: String| {
                     let delay = input.parse::<u64>().unwrap_or(current_delay);
                     Message::SetConfig(SetConfigFields::DebounceDelay(delay))
                 })
                 .on_submit(Message::WriteConfig(false))
-                .width(Length::Fill)
+                .width(Length::Fixed(250.0))
                 .style(move |_, _| settings_text_input_item_style(&theme_clone))
                 .into(),
-            notice_item(
-                theme.clone(),
-                "How quickly you want file searching to return a value",
-            ),
         ]),
         ResetField::DebounceDelay,
         theme.clone(),
     );
 
-    let start_at_login = settings_row_with_reset(
-        settings_item_row([
-            settings_hint_text(theme.clone(), "Start at login"),
-            toggler(config.clone().start_at_login)
-                .style(move |_, status| settings_toggle_style(status))
-                .on_toggle(Message::ToggleAutoStartup)
-                .into(),
-            notice_item(theme.clone(), "If you want rustcast to start on login"),
-        ]),
-        ResetField::StartAtLogin,
-        theme.clone(),
-    );
+    let start_at_login = settings_row_without_reset(settings_item_row([
+        settings_hint_text(theme.clone(), "Start at login", None::<String>),
+        Space::new().width(Length::Fill).into(),
+        toggler(config.clone().start_at_login)
+            .style(move |_, status| settings_toggle_style(status))
+            .on_toggle(Message::ToggleAutoStartup)
+            .into(),
+    ]));
 
-    let auto_update = settings_row_with_reset(
-        settings_item_row([
-            settings_hint_text(theme.clone(), "Auto update"),
-            toggler(config.clone().auto_update)
-                .style(move |_, status| settings_toggle_style(status))
-                .on_toggle(move |input| Message::SetConfig(SetConfigFields::SetAutoUpdate(input)))
-                .into(),
-            notice_item(
-                theme.clone(),
-                "If rustcast should automatically update itself",
-            ),
-        ]),
-        ResetField::AutoUpdate,
-        theme.clone(),
-    );
+    let auto_update = settings_row_without_reset(settings_item_row([
+        settings_hint_text(theme.clone(), "Auto update", None::<String>),
+        Space::new().width(Length::Fill).into(),
+        toggler(config.clone().auto_update)
+            .style(move |_, status| settings_toggle_style(status))
+            .on_toggle(move |input| Message::SetConfig(SetConfigFields::SetAutoUpdate(input)))
+            .into(),
+    ]));
 
-    let haptic = settings_row_with_reset(
+    let haptic = settings_row_without_reset(
         Row::from_iter([
-            settings_hint_text(theme.clone(), "Haptic feedback"),
+            settings_hint_text(theme.clone(), "Haptic feedback", None::<String>),
+            Space::new().width(Length::Fill).into(),
             toggler(config.clone().haptic_feedback)
                 .style(move |_, status| settings_toggle_style(status))
                 .on_toggle(|input| Message::SetConfig(SetConfigFields::HapticFeedback(input)))
                 .into(),
-            notice_item(
-                theme.clone(),
-                "If there should be haptic feedback when you type",
-            ),
         ])
         .align_y(Alignment::Center)
         .spacing(SETTINGS_ITEM_COL_SPACING * 2)
         .padding(SETTINGS_ITEM_PADDING)
         .height(SETTINGS_ITEM_HEIGHT),
-        ResetField::HapticFeedback,
-        theme.clone(),
     );
 
-    let tray_icon = settings_row_with_reset(
-        settings_item_row([
-            settings_hint_text(theme.clone(), "Show menubar icon"),
-            toggler(config.clone().show_trayicon)
-                .style(move |_, status| settings_toggle_style(status))
-                .on_toggle(|input| Message::SetConfig(SetConfigFields::ShowMenubarIcon(input)))
-                .into(),
-            notice_item(
-                theme.clone(),
-                "If the menubar icon should be shown in rustcast",
-            ),
-        ]),
-        ResetField::ShowMenubarIcon,
-        theme.clone(),
-    );
+    let tray_icon = settings_row_without_reset(settings_item_row([
+        settings_hint_text(theme.clone(), "Show menubar icon", None::<String>),
+        Space::new().width(Length::Fill).into(),
+        toggler(config.clone().show_trayicon)
+            .style(move |_, status| settings_toggle_style(status))
+            .on_toggle(|input| Message::SetConfig(SetConfigFields::ShowMenubarIcon(input)))
+            .into(),
+    ]));
 
-    let clipboard_history = settings_row_with_reset(
+    let clipboard_history = settings_row_without_reset(
         Row::from_iter([
-            settings_hint_text(theme.clone(), "Enable Clipboard history"),
+            settings_hint_text(theme.clone(), "Enable Clipboard history", None::<String>),
+            Space::new().width(Length::Fill).into(),
             toggler(config.clone().cbhist)
                 .style(move |_, status| settings_toggle_style(status))
                 .on_toggle(|input| Message::SetConfig(SetConfigFields::ClipboardHistory(input)))
                 .into(),
-            notice_item(
-                theme.clone(),
-                "If you want your clipboard history to be stored",
-            ),
         ])
         .align_y(Alignment::Center)
         .spacing(SETTINGS_ITEM_COL_SPACING * 2)
         .padding(SETTINGS_ITEM_PADDING)
         .height(SETTINGS_ITEM_HEIGHT),
-        ResetField::ClipboardHistory,
-        theme.clone(),
     );
 
-    let cbhist_paste_on_select = settings_row_with_reset(
+    let cbhist_paste_on_select = settings_row_without_reset(
         Row::from_iter([
-            settings_hint_text(theme.clone(), "Paste on select"),
+            settings_hint_text(theme.clone(), "Paste on select", None::<String>),
+            Space::new().width(Length::Fill).into(),
             toggler(config.clone().cbhist_paste_on_select)
                 .style(move |_, status| settings_toggle_style(status))
                 .on_toggle(|input| {
                     Message::SetConfig(SetConfigFields::ClipboardPasteOnSelect(input))
                 })
                 .into(),
-            notice_item(theme.clone(), "Auto-paste clipboard item after selecting"),
         ])
         .align_y(Alignment::Center)
         .spacing(SETTINGS_ITEM_COL_SPACING * 2)
         .padding(SETTINGS_ITEM_PADDING)
         .height(SETTINGS_ITEM_HEIGHT),
-        ResetField::ClipboardPasteOnSelect,
-        theme.clone(),
     );
 
     let theme_clone = theme.clone();
     let auto_suggest = settings_row_with_reset(
         settings_item_column([
-            settings_hint_text(theme.clone(), "Suggestions on open"),
+            settings_hint_text(
+                theme.clone(),
+                "Suggestions on open",
+                Some("What an empty query should show"),
+            ),
             settings_item_row([
                 radio(
                     "Favourites",
@@ -392,7 +383,6 @@ fn general_tab(config: Box<Config>, theme: crate::config::Theme) -> Column<'stat
             ])
             .spacing(30)
             .into(),
-            notice_item(theme.clone(), "What an empty query should show"),
         ]),
         ResetField::MainPage,
         theme.clone(),
@@ -417,142 +407,117 @@ fn general_tab(config: Box<Config>, theme: crate::config::Theme) -> Column<'stat
 
 fn appearance_tab(config: Box<Config>, theme: crate::config::Theme) -> Column<'static, Message> {
     let theme_clone = theme.clone();
-    let theme_mode_setting = settings_row_with_reset(
-        settings_item_column([
-            settings_hint_text(theme.clone(), "Theme mode"),
-            settings_item_row([
-                radio(
-                    "Dark",
-                    ThemeMode::Dark,
-                    Some(config.theme.theme_mode),
-                    |mode| {
-                        Message::SetConfig(SetConfigFields::SetThemeFields(
-                            SetConfigThemeFields::ThemeMode(mode),
-                        ))
-                    },
-                )
-                .style({
-                    let theme_clone = theme_clone.clone();
-                    move |_, _| settings_radio_button_style(&theme_clone.clone())
-                })
-                .into(),
-                radio(
-                    "Light",
-                    ThemeMode::Light,
-                    Some(config.theme.theme_mode),
-                    |mode| {
-                        Message::SetConfig(SetConfigFields::SetThemeFields(
-                            SetConfigThemeFields::ThemeMode(mode),
-                        ))
-                    },
-                )
-                .style({
-                    let theme_clone = theme_clone.clone();
-                    move |_, _| settings_radio_button_style(&theme_clone.clone())
-                })
-                .into(),
-                radio(
-                    "System",
-                    ThemeMode::System,
-                    Some(config.theme.theme_mode),
-                    |mode| {
-                        Message::SetConfig(SetConfigFields::SetThemeFields(
-                            SetConfigThemeFields::ThemeMode(mode),
-                        ))
-                    },
-                )
-                .style(move |_, _| settings_radio_button_style(&theme_clone.clone()))
-                .into(),
-            ])
-            .spacing(30)
+    let theme_mode_setting = settings_row_without_reset(settings_item_column([
+        settings_hint_text(theme.clone(), "Theme mode", None::<String>),
+        settings_item_row([
+            radio(
+                "Dark",
+                ThemeMode::Dark,
+                Some(config.theme.theme_mode),
+                |mode| {
+                    Message::SetConfig(SetConfigFields::SetThemeFields(
+                        SetConfigThemeFields::ThemeMode(mode),
+                    ))
+                },
+            )
+            .style({
+                let theme_clone = theme_clone.clone();
+                move |_, _| settings_radio_button_style(&theme_clone.clone())
+            })
             .into(),
-            notice_item(
-                theme.clone(),
-                "System follows the macOS appearance automatically",
-            ),
-        ]),
-        ResetField::ThemeMode,
-        theme.clone(),
-    );
-
-    let show_scrollbar = settings_row_with_reset(
-        settings_item_row([
-            settings_hint_text(theme.clone(), "Show scrollbar"),
-            toggler(config.theme.show_scroll_bar)
-                .style(move |_, status| settings_toggle_style(status))
-                .on_toggle(|input| {
+            radio(
+                "Light",
+                ThemeMode::Light,
+                Some(config.theme.theme_mode),
+                |mode| {
                     Message::SetConfig(SetConfigFields::SetThemeFields(
-                        SetConfigThemeFields::ShowScrollBar(input),
+                        SetConfigThemeFields::ThemeMode(mode),
                     ))
-                })
-                .into(),
-            notice_item(theme.clone(), "If there should be a scrollbar"),
-        ]),
-        ResetField::ShowScrollbar,
-        theme.clone(),
-    );
-
-    let clear_on_hide = settings_row_with_reset(
-        settings_item_row([
-            settings_hint_text(theme.clone(), "Clear on hide"),
-            toggler(config.clone().buffer_rules.clear_on_hide)
-                .style(move |_, status| settings_toggle_style(status))
-                .on_toggle(move |input| {
-                    Message::SetConfig(SetConfigFields::SetBufferFields(
-                        SetConfigBufferFields::ClearOnHide(input),
-                    ))
-                })
-                .into(),
-            notice_item(
-                theme.clone(),
-                "If the query should be cleared when rustcast is hidden",
-            ),
-        ]),
-        ResetField::ClearOnHide,
-        theme.clone(),
-    );
-
-    let clear_on_enter = settings_row_with_reset(
-        settings_item_row([
-            settings_hint_text(theme.clone(), "Clear on enter"),
-            toggler(config.clone().buffer_rules.clear_on_enter)
-                .style(move |_, status| settings_toggle_style(status))
-                .on_toggle(move |input| {
-                    Message::SetConfig(SetConfigFields::SetBufferFields(
-                        SetConfigBufferFields::ClearOnEnter(input),
-                    ))
-                })
-                .into(),
-            notice_item(
-                theme.clone(),
-                "If the query should be cleared when an app is opened",
-            ),
-        ]),
-        ResetField::ClearOnEnter,
-        theme.clone(),
-    );
-
-    let show_icons = settings_row_with_reset(
-        settings_item_row([
-            settings_hint_text(theme.clone(), "Show icons"),
-            toggler(config.clone().theme.show_icons)
-                .style(move |_, status| settings_toggle_style(status))
-                .on_toggle(move |input| {
+                },
+            )
+            .style({
+                let theme_clone = theme_clone.clone();
+                move |_, _| settings_radio_button_style(&theme_clone.clone())
+            })
+            .into(),
+            radio(
+                "System",
+                ThemeMode::System,
+                Some(config.theme.theme_mode),
+                |mode| {
                     Message::SetConfig(SetConfigFields::SetThemeFields(
-                        SetConfigThemeFields::ShowIcons(input),
+                        SetConfigThemeFields::ThemeMode(mode),
                     ))
-                })
-                .into(),
-            notice_item(theme.clone(), "If you want app icons to be visible"),
-        ]),
-        ResetField::ShowIcons,
-        theme.clone(),
-    );
+                },
+            )
+            .style(move |_, _| settings_radio_button_style(&theme_clone.clone()))
+            .into(),
+        ])
+        .spacing(30)
+        .into(),
+    ]));
+
+    let show_scrollbar = settings_row_without_reset(settings_item_row([
+        settings_hint_text(theme.clone(), "Show scrollbar", None::<String>),
+        Space::new().width(Length::Fill).into(),
+        toggler(config.theme.show_scroll_bar)
+            .style(move |_, status| settings_toggle_style(status))
+            .on_toggle(|input| {
+                Message::SetConfig(SetConfigFields::SetThemeFields(
+                    SetConfigThemeFields::ShowScrollBar(input),
+                ))
+            })
+            .into(),
+    ]));
+
+    let clear_on_hide = settings_row_without_reset(settings_item_row([
+        settings_hint_text(
+            theme.clone(),
+            "Clear on hide",
+            Some("If the query should be cleared when rustcast is hidden"),
+        ),
+        Space::new().width(Length::Fill).into(),
+        toggler(config.clone().buffer_rules.clear_on_hide)
+            .style(move |_, status| settings_toggle_style(status))
+            .on_toggle(move |input| {
+                Message::SetConfig(SetConfigFields::SetBufferFields(
+                    SetConfigBufferFields::ClearOnHide(input),
+                ))
+            })
+            .into(),
+    ]));
+
+    let clear_on_enter = settings_row_without_reset(settings_item_row([
+        settings_hint_text(theme.clone(), "Clear on enter", None::<String>),
+        Space::new().width(Length::Fill).into(),
+        toggler(config.clone().buffer_rules.clear_on_enter)
+            .style(move |_, status| settings_toggle_style(status))
+            .on_toggle(move |input| {
+                Message::SetConfig(SetConfigFields::SetBufferFields(
+                    SetConfigBufferFields::ClearOnEnter(input),
+                ))
+            })
+            .into(),
+    ]));
+
+    let show_icons = settings_row_without_reset(settings_item_row([
+        settings_hint_text(theme.clone(), "Show icons", None::<String>),
+        Space::new().width(Length::Fill).into(),
+        toggler(config.clone().theme.show_icons)
+            .style(move |_, status| settings_toggle_style(status))
+            .on_toggle(move |input| {
+                Message::SetConfig(SetConfigFields::SetThemeFields(
+                    SetConfigThemeFields::ShowIcons(input),
+                ))
+            })
+            .into(),
+    ]));
 
     let theme_clone = theme.clone();
     let font_family = settings_row_with_reset(
-        settings_item_column([
-            settings_hint_text(theme.clone(), "Set Font family"),
+        settings_item_row([
+            settings_hint_text(theme.clone(), "Set Font family", None::<String>),
+            Space::new().width(Length::Fill).into(),
             text_input(
                 "Font family",
                 &config.theme.font.clone().unwrap_or("".to_string()),
@@ -563,10 +528,9 @@ fn appearance_tab(config: Box<Config>, theme: crate::config::Theme) -> Column<'s
                 )))
             })
             .on_submit(Message::WriteConfig(false))
-            .width(Length::Fill)
+            .width(Length::Fixed(250.0))
             .style(move |_, _| settings_text_input_item_style(&theme_clone))
             .into(),
-            notice_item(theme.clone(), "What font rustcast should use"),
         ]),
         ResetField::Font,
         theme.clone(),
@@ -574,20 +538,21 @@ fn appearance_tab(config: Box<Config>, theme: crate::config::Theme) -> Column<'s
 
     let theme_clone = theme.clone();
     let event_duration = settings_row_with_reset(
-        settings_item_column([
-            settings_hint_text(theme.clone(), "Set Event duration"),
+        settings_item_row([
+            settings_hint_text(
+                theme.clone(),
+                "Set Event duration",
+                Some("Minutes from now events should be displayed"),
+            ),
+            Space::new().width(Length::Fill).into(),
             text_input("Event duration", &config.event_duration.to_string())
                 .on_input(move |input: String| {
                     Message::SetConfig(SetConfigFields::SetEventDuration(input))
                 })
                 .on_submit(Message::WriteConfig(false))
-                .width(Length::Fill)
+                .width(Length::Fixed(250.0))
                 .style(move |_, _| settings_text_input_item_style(&theme_clone))
                 .into(),
-            notice_item(
-                theme.clone(),
-                "How many minutes from now the events should be displayed",
-            ),
         ]),
         ResetField::EventDuration,
         theme.clone(),
@@ -599,11 +564,12 @@ fn appearance_tab(config: Box<Config>, theme: crate::config::Theme) -> Column<'s
     let theme_clone_3 = theme.clone();
     let text_clr = settings_row_with_reset(
         Column::from_iter([
-            settings_hint_text(theme.clone(), "Set text colour"),
+            settings_hint_text(theme.clone(), "Set text colour", None::<String>),
             Column::from_iter([
                 settings_hint_text(
                     theme.clone(),
                     format!("R value: {}", theme_clone.text_color.0),
+                    None::<String>,
                 ),
                 Slider::new(
                     0..=100,
@@ -622,6 +588,7 @@ fn appearance_tab(config: Box<Config>, theme: crate::config::Theme) -> Column<'s
                 settings_hint_text(
                     theme.clone(),
                     format!("G value: {}", theme_clone.text_color.1),
+                    None::<String>,
                 ),
                 Slider::new(
                     0..=100,
@@ -640,6 +607,7 @@ fn appearance_tab(config: Box<Config>, theme: crate::config::Theme) -> Column<'s
                 settings_hint_text(
                     theme.clone(),
                     format!("B value: {}", theme_clone.text_color.2),
+                    None::<String>,
                 ),
                 Slider::new(
                     0..=100,
@@ -672,11 +640,12 @@ fn appearance_tab(config: Box<Config>, theme: crate::config::Theme) -> Column<'s
     let theme_clone_3 = theme.clone();
     let bg_clr = settings_row_with_reset(
         Column::from_iter([
-            settings_hint_text(theme.clone(), "Set background colour"),
+            settings_hint_text(theme.clone(), "Set background colour", None::<String>),
             Column::from_iter([
                 settings_hint_text(
                     theme.clone(),
                     format!("R value: {}", theme_clone.background_color.0),
+                    None::<String>,
                 ),
                 Slider::new(
                     0..=100,
@@ -695,6 +664,7 @@ fn appearance_tab(config: Box<Config>, theme: crate::config::Theme) -> Column<'s
                 settings_hint_text(
                     theme.clone(),
                     format!("G value: {}", theme_clone.background_color.1),
+                    None::<String>,
                 ),
                 Slider::new(
                     0..=100,
@@ -713,6 +683,7 @@ fn appearance_tab(config: Box<Config>, theme: crate::config::Theme) -> Column<'s
                 settings_hint_text(
                     theme.clone(),
                     format!("B value: {}", theme_clone.background_color.2),
+                    None::<String>,
                 ),
                 Slider::new(
                     0..=100,
@@ -774,7 +745,7 @@ fn section_header_with_reset(
     theme: crate::config::Theme,
 ) -> Element<'static, Message> {
     Row::from_iter([
-        settings_hint_text(theme.clone(), label),
+        settings_hint_text(theme.clone(), label, None::<String>),
         reset_button(theme, field),
     ])
     .align_y(Alignment::Center)
@@ -789,6 +760,16 @@ fn settings_row_with_reset(
     theme: crate::config::Theme,
 ) -> Element<'static, Message> {
     Row::from_iter([content.into(), reset_button(theme, field)])
+        .align_y(Alignment::Center)
+        .spacing(5)
+        .width(Length::Fill)
+        .into()
+}
+
+fn settings_row_without_reset(
+    content: impl Into<Element<'static, Message>>,
+) -> Element<'static, Message> {
+    Row::from_iter([content.into()])
         .align_y(Alignment::Center)
         .spacing(5)
         .width(Length::Fill)
@@ -841,13 +822,25 @@ fn copy_config_button(config: Box<Config>) -> Element<'static, Message> {
     .into()
 }
 
-fn settings_hint_text(theme: Theme, text: impl ToString) -> Element<'static, Message> {
-    let text = text.to_string();
-
-    Text::new(text)
+fn settings_hint_text(
+    theme: Theme,
+    text: impl ToString,
+    subtitle: Option<impl ToString>,
+) -> Element<'static, Message> {
+    let title = Text::new(text.to_string())
         .font(theme.font())
-        .color(theme.text_color(0.7))
-        .into()
+        .color(theme.text_color(0.7));
+
+    let mut content = Column::new().push(title);
+
+    if let Some(subtitle) = subtitle {
+        let subtitle = Text::new(subtitle.to_string())
+            .font(theme.font())
+            .color(theme.text_color(0.3));
+        content = content.push(subtitle);
+    }
+
+    container(content).into()
 }
 
 fn settings_item_column(

--- a/src/app/pages/settings.rs
+++ b/src/app/pages/settings.rs
@@ -9,12 +9,13 @@ use iced::widget::Slider;
 use iced::widget::Space;
 use iced::widget::TextInput;
 use iced::widget::button;
-use iced::widget::checkbox;
 use iced::widget::radio;
 use iced::widget::text_input;
+use iced::widget::toggler;
 
 use crate::styles::settings_contents_container_style;
 use crate::styles::settings_tabs_container_style;
+use crate::styles::settings_toggle_style;
 use crate::styles::tint;
 use crate::styles::with_alpha;
 
@@ -30,7 +31,6 @@ use crate::config::Shelly;
 use crate::config::ThemeMode;
 use crate::styles::delete_button_style;
 use crate::styles::settings_add_button_style;
-use crate::styles::settings_checkbox_style;
 use crate::styles::settings_radio_button_style;
 use crate::styles::settings_save_button_style;
 use crate::styles::settings_slider_style;
@@ -130,7 +130,7 @@ fn tab_button(
 fn reset_button(theme: crate::config::Theme, field: ResetField) -> Element<'static, Message> {
     let theme_clone = theme.clone();
     Button::new(
-        Text::new("R")
+        Text::new("⟳")
             .align_x(Alignment::Center)
             .align_y(Alignment::Center)
             .size(13)
@@ -245,12 +245,11 @@ fn general_tab(config: Box<Config>, theme: crate::config::Theme) -> Column<'stat
         theme.clone(),
     );
 
-    let theme_clone = theme.clone();
     let start_at_login = settings_row_with_reset(
         settings_item_row([
             settings_hint_text(theme.clone(), "Start at login"),
-            checkbox(config.clone().start_at_login)
-                .style(move |_, _| settings_checkbox_style(&theme_clone))
+            toggler(config.clone().start_at_login)
+                .style(move |_, status| settings_toggle_style(status))
                 .on_toggle(Message::ToggleAutoStartup)
                 .into(),
             notice_item(theme.clone(), "If you want rustcast to start on login"),
@@ -259,12 +258,11 @@ fn general_tab(config: Box<Config>, theme: crate::config::Theme) -> Column<'stat
         theme.clone(),
     );
 
-    let theme_clone = theme.clone();
     let auto_update = settings_row_with_reset(
         settings_item_row([
             settings_hint_text(theme.clone(), "Auto update"),
-            checkbox(config.clone().auto_update)
-                .style(move |_, _| settings_checkbox_style(&theme_clone))
+            toggler(config.clone().auto_update)
+                .style(move |_, status| settings_toggle_style(status))
                 .on_toggle(move |input| Message::SetConfig(SetConfigFields::SetAutoUpdate(input)))
                 .into(),
             notice_item(
@@ -276,12 +274,11 @@ fn general_tab(config: Box<Config>, theme: crate::config::Theme) -> Column<'stat
         theme.clone(),
     );
 
-    let theme_clone = theme.clone();
     let haptic = settings_row_with_reset(
         Row::from_iter([
             settings_hint_text(theme.clone(), "Haptic feedback"),
-            checkbox(config.clone().haptic_feedback)
-                .style(move |_, _| settings_checkbox_style(&theme_clone))
+            toggler(config.clone().haptic_feedback)
+                .style(move |_, status| settings_toggle_style(status))
                 .on_toggle(|input| Message::SetConfig(SetConfigFields::HapticFeedback(input)))
                 .into(),
             notice_item(
@@ -297,12 +294,11 @@ fn general_tab(config: Box<Config>, theme: crate::config::Theme) -> Column<'stat
         theme.clone(),
     );
 
-    let theme_clone = theme.clone();
     let tray_icon = settings_row_with_reset(
         settings_item_row([
             settings_hint_text(theme.clone(), "Show menubar icon"),
-            checkbox(config.clone().show_trayicon)
-                .style(move |_, _| settings_checkbox_style(&theme_clone))
+            toggler(config.clone().show_trayicon)
+                .style(move |_, status| settings_toggle_style(status))
                 .on_toggle(|input| Message::SetConfig(SetConfigFields::ShowMenubarIcon(input)))
                 .into(),
             notice_item(
@@ -314,12 +310,11 @@ fn general_tab(config: Box<Config>, theme: crate::config::Theme) -> Column<'stat
         theme.clone(),
     );
 
-    let theme_clone = theme.clone();
     let clipboard_history = settings_row_with_reset(
         Row::from_iter([
             settings_hint_text(theme.clone(), "Enable Clipboard history"),
-            checkbox(config.clone().cbhist)
-                .style(move |_, _| settings_checkbox_style(&theme_clone))
+            toggler(config.clone().cbhist)
+                .style(move |_, status| settings_toggle_style(status))
                 .on_toggle(|input| Message::SetConfig(SetConfigFields::ClipboardHistory(input)))
                 .into(),
             notice_item(
@@ -335,12 +330,11 @@ fn general_tab(config: Box<Config>, theme: crate::config::Theme) -> Column<'stat
         theme.clone(),
     );
 
-    let theme_clone = theme.clone();
     let cbhist_paste_on_select = settings_row_with_reset(
         Row::from_iter([
             settings_hint_text(theme.clone(), "Paste on select"),
-            checkbox(config.clone().cbhist_paste_on_select)
-                .style(move |_, _| settings_checkbox_style(&theme_clone))
+            toggler(config.clone().cbhist_paste_on_select)
+                .style(move |_, status| settings_toggle_style(status))
                 .on_toggle(|input| {
                     Message::SetConfig(SetConfigFields::ClipboardPasteOnSelect(input))
                 })
@@ -481,12 +475,11 @@ fn appearance_tab(config: Box<Config>, theme: crate::config::Theme) -> Column<'s
         theme.clone(),
     );
 
-    let theme_clone = theme.clone();
     let show_scrollbar = settings_row_with_reset(
         settings_item_row([
             settings_hint_text(theme.clone(), "Show scrollbar"),
-            checkbox(config.theme.show_scroll_bar)
-                .style(move |_, _| settings_checkbox_style(&theme_clone))
+            toggler(config.theme.show_scroll_bar)
+                .style(move |_, status| settings_toggle_style(status))
                 .on_toggle(|input| {
                     Message::SetConfig(SetConfigFields::SetThemeFields(
                         SetConfigThemeFields::ShowScrollBar(input),
@@ -499,12 +492,11 @@ fn appearance_tab(config: Box<Config>, theme: crate::config::Theme) -> Column<'s
         theme.clone(),
     );
 
-    let theme_clone = theme.clone();
     let clear_on_hide = settings_row_with_reset(
         settings_item_row([
             settings_hint_text(theme.clone(), "Clear on hide"),
-            checkbox(config.clone().buffer_rules.clear_on_hide)
-                .style(move |_, _| settings_checkbox_style(&theme_clone))
+            toggler(config.clone().buffer_rules.clear_on_hide)
+                .style(move |_, status| settings_toggle_style(status))
                 .on_toggle(move |input| {
                     Message::SetConfig(SetConfigFields::SetBufferFields(
                         SetConfigBufferFields::ClearOnHide(input),
@@ -520,12 +512,11 @@ fn appearance_tab(config: Box<Config>, theme: crate::config::Theme) -> Column<'s
         theme.clone(),
     );
 
-    let theme_clone = theme.clone();
     let clear_on_enter = settings_row_with_reset(
         settings_item_row([
             settings_hint_text(theme.clone(), "Clear on enter"),
-            checkbox(config.clone().buffer_rules.clear_on_enter)
-                .style(move |_, _| settings_checkbox_style(&theme_clone))
+            toggler(config.clone().buffer_rules.clear_on_enter)
+                .style(move |_, status| settings_toggle_style(status))
                 .on_toggle(move |input| {
                     Message::SetConfig(SetConfigFields::SetBufferFields(
                         SetConfigBufferFields::ClearOnEnter(input),
@@ -541,12 +532,11 @@ fn appearance_tab(config: Box<Config>, theme: crate::config::Theme) -> Column<'s
         theme.clone(),
     );
 
-    let theme_clone = theme.clone();
     let show_icons = settings_row_with_reset(
         settings_item_row([
             settings_hint_text(theme.clone(), "Show icons"),
-            checkbox(config.clone().theme.show_icons)
-                .style(move |_, _| settings_checkbox_style(&theme_clone))
+            toggler(config.clone().theme.show_icons)
+                .style(move |_, status| settings_toggle_style(status))
                 .on_toggle(move |input| {
                     Message::SetConfig(SetConfigFields::SetThemeFields(
                         SetConfigThemeFields::ShowIcons(input),

--- a/src/app/pages/settings.rs
+++ b/src/app/pages/settings.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 
 use iced::Border;
 use iced::border::Radius;
+use iced::widget::Container;
 use iced::widget::Slider;
 use iced::widget::Space;
 use iced::widget::TextInput;
@@ -12,6 +13,8 @@ use iced::widget::checkbox;
 use iced::widget::radio;
 use iced::widget::text_input;
 
+use crate::styles::settings_contents_container_style;
+use crate::styles::settings_tabs_container_style;
 use crate::styles::tint;
 use crate::styles::with_alpha;
 
@@ -28,7 +31,6 @@ use crate::config::ThemeMode;
 use crate::styles::delete_button_style;
 use crate::styles::settings_add_button_style;
 use crate::styles::settings_checkbox_style;
-use crate::styles::settings_container_style;
 use crate::styles::settings_radio_button_style;
 use crate::styles::settings_save_button_style;
 use crate::styles::settings_slider_style;
@@ -47,7 +49,7 @@ pub fn settings_page(config: Config, settings_tab: SettingsTab) -> Element<'stat
     let config = Box::new(config.clone());
     let theme = config.theme.clone();
 
-    let tabs_row = Row::from_iter([
+    let tabs_column = Column::from_iter([
         tab_button("General", SettingsTab::General, settings_tab, theme.clone()),
         tab_button(
             "Appearance",
@@ -62,8 +64,15 @@ pub fn settings_page(config: Config, settings_tab: SettingsTab) -> Element<'stat
             theme.clone(),
         ),
     ])
-    .spacing(2)
-    .width(Length::Fill);
+    .spacing(2);
+
+    let theme_clone = theme.clone();
+    let tabs_container = Container::new(tabs_column)
+        .style(move |_| settings_tabs_container_style(&theme_clone))
+        .height(Length::Fill)
+        .width(Length::Fixed(200.0))
+        .padding(12)
+        .align_x(Alignment::Center);
 
     let tab_content: Column<'static, Message> = match settings_tab {
         SettingsTab::General => general_tab(config.clone(), theme.clone()),
@@ -71,8 +80,7 @@ pub fn settings_page(config: Config, settings_tab: SettingsTab) -> Element<'stat
         SettingsTab::Commands => commands_tab(config.clone(), theme.clone()),
     };
 
-    let items = Column::from_iter([
-        tabs_row.into(),
+    let contents_column = Column::from_iter([
         tab_content.into(),
         Space::new().height(10).into(),
         Row::from_iter([
@@ -80,18 +88,22 @@ pub fn settings_page(config: Config, settings_tab: SettingsTab) -> Element<'stat
             copy_config_button(config),
             wiki_button(theme.clone()),
         ])
-        .spacing(5)
         .width(Length::Fill)
         .into(),
-    ])
-    .spacing(10);
+    ]);
 
-    container(items)
-        .style(move |_| settings_container_style(&theme))
+    let contents_container = Container::new(contents_column)
+        .style(move |_| settings_contents_container_style(&theme))
         .height(Length::Fill)
         .width(Length::Fill)
         .padding(12)
-        .align_x(Alignment::Center)
+        .align_x(Alignment::Center);
+
+    let items = Row::from_iter([tabs_container.into(), contents_container.into()]);
+
+    container(items)
+        .height(Length::Fill)
+        .width(Length::Fill)
         .into()
 }
 

--- a/src/app/tile.rs
+++ b/src/app/tile.rs
@@ -175,6 +175,7 @@ fn build_mdfind_args(query: &str, dirs: &[String], home_dir: &str) -> Option<Vec
 /// - Clipboard Content (`Vec<`[`ClipBoardContentType`]`>`) all of the cliboard contents
 /// - Page ([`Page`]) the current page of the window (main or clipboard history)
 /// - RustCast's height: to figure out which height to resize to
+/// - Settings Window: the ID of the window if it is open
 #[derive(Clone)]
 pub struct Tile {
     pub theme: iced::Theme,
@@ -202,6 +203,7 @@ pub struct Tile {
     pub file_dialog_open: bool,
     pub settings_tab: crate::app::SettingsTab,
     debouncer: Debouncer,
+    pub settings_window: Option<window::Id>,
 }
 
 /// A struct to store all the hotkeys
@@ -255,7 +257,7 @@ impl Tile {
                 ..
             }) => {
                 if cha.to_string() == "," {
-                    return Some(Message::SwitchToPage(Page::Settings));
+                    return Some(Message::OpenSettingsWindow);
                 }
                 None
             }

--- a/src/app/tile/elm.rs
+++ b/src/app/tile/elm.rs
@@ -100,6 +100,7 @@ pub fn new(hotkeys: Hotkeys, config: &Config) -> (Tile, Task<Message>) {
             file_dialog_open: false,
             settings_tab: SettingsTab::General,
             debouncer: Debouncer::new(config.debounce_delay),
+            settings_window: None,
         },
         Task::batch([open.map(|_| Message::OpenWindow)]),
     )
@@ -107,6 +108,10 @@ pub fn new(hotkeys: Hotkeys, config: &Config) -> (Tile, Task<Message>) {
 
 /// The elm View function that renders the entire rustcast window
 pub fn view(tile: &Tile, wid: window::Id) -> Element<'_, Message> {
+    if tile.settings_window == Some(wid) {
+        return settings_page(tile.config.clone(), tile.settings_tab);
+    };
+
     if tile.visible {
         let title_input = text_input(tile.config.placeholder.as_str(), &tile.query)
             .on_input(move |a| Message::SearchQueryChanged(a, wid))
@@ -119,17 +124,16 @@ pub fn view(tile: &Tile, wid: window::Id) -> Element<'_, Message> {
             .style(move |_, _| rustcast_text_input_style(&tile.config.theme))
             .padding(20);
 
-        let scrollbar_direction =
-            if !tile.config.theme.show_scroll_bar || tile.page == Page::Settings {
-                Direction::Vertical(Scrollbar::hidden())
-            } else {
-                Direction::Vertical(
-                    Scrollbar::new()
-                        .width(1)
-                        .scroller_width(1.1)
-                        .anchor(Anchor::Start),
-                )
-            };
+        let scrollbar_direction = if !tile.config.theme.show_scroll_bar {
+            Direction::Vertical(Scrollbar::hidden())
+        } else {
+            Direction::Vertical(
+                Scrollbar::new()
+                    .width(1)
+                    .scroller_width(1.1)
+                    .anchor(Anchor::Start),
+            )
+        };
 
         let results = match tile.page {
             Page::ClipboardHistory => clipboard_view(
@@ -145,7 +149,6 @@ pub fn view(tile: &Tile, wid: window::Id) -> Element<'_, Message> {
                     .collect(),
                 tile.focus_id,
             ),
-            Page::Settings => settings_page(tile.config.clone(), tile.settings_tab),
             Page::FileSearch | Page::Main => container(Column::from_iter(
                 tile.results.iter().enumerate().map(|(i, app)| {
                     app.clone().render(
@@ -162,12 +165,11 @@ pub fn view(tile: &Tile, wid: window::Id) -> Element<'_, Message> {
         let results_count = match &tile.page {
             Page::Main | Page::EmojiSearch | Page::FileSearch => tile.results.len(),
             Page::ClipboardHistory => tile.clipboard_content.len(),
-            Page::Settings => 0,
         };
 
         // This determines the height of the scrollable window
         let height = match tile.page {
-            Page::ClipboardHistory | Page::Settings => 385,
+            Page::ClipboardHistory => 385,
             // Height of each emoji is EMOJI_HEIGHT + 20 for padding
             Page::EmojiSearch => std::cmp::min(tile.results.len().div_ceil(6) * 90, 290),
             _ => std::cmp::min(tile.results.len() * 60, 290),

--- a/src/app/tile/update.rs
+++ b/src/app/tile/update.rs
@@ -1011,6 +1011,7 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
                     tile.config.cbhist_paste_on_select = default.cbhist_paste_on_select
                 }
             }
+            tile.theme = tile.config.theme.clone().into();
             Task::none()
         }
         Message::WriteConfig => {

--- a/src/app/tile/update.rs
+++ b/src/app/tile/update.rs
@@ -542,6 +542,10 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
             if tile.file_dialog_open {
                 return Task::none();
             }
+            if tile.settings_window == Some(a) {
+                tile.settings_window = None;
+                return Task::none();
+            }
             info!("Hiding RustCast window");
             tile.visible = false;
             tile.focused = false;
@@ -1009,7 +1013,7 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
             }
             Task::none()
         }
-        Message::WriteConfig(page_switch) => {
+        Message::WriteConfig => {
             let config_file_path =
                 std::env::var("HOME").unwrap_or("".to_string()) + "/.config/rustcast/config.toml";
 
@@ -1032,14 +1036,7 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
                 })
                 .ok();
 
-            Task::batch([
-                Task::done(Message::ReloadConfig),
-                if page_switch {
-                    Task::done(Message::SwitchToPage(Page::Main))
-                } else {
-                    Task::none()
-                },
-            ])
+            Task::batch([Task::done(Message::ReloadConfig), Task::none()])
         }
         Message::ClearClipboardHistory => {
             tile.clipboard_content.clear();

--- a/src/app/tile/update.rs
+++ b/src/app/tile/update.rs
@@ -1497,10 +1497,8 @@ mod tests {
 
         let _ = open_result(&mut tile, 0);
         let _ = open_result(&mut tile, 1);
-        let _ = open_result(&mut tile, 2);
 
         assert_eq!(tile.options.get_rankings().get("openable"), Some(&1));
-        assert_eq!(tile.options.get_rankings().get("message"), Some(&1));
         assert_eq!(tile.options.get_rankings().get("display"), None);
     }
 }

--- a/src/app/tile/update.rs
+++ b/src/app/tile/update.rs
@@ -924,9 +924,10 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
                 SetConfigFields::SetThemeFields(SetConfigThemeFields::ThemeMode(mode)) => {
                     final_config.theme.theme_mode = mode;
                     let is_dark = crate::platform::macos::is_dark_mode();
-                    let (text, bg) = mode.presets(is_dark);
+                    let (text, bg, secondary) = mode.presets(is_dark);
                     final_config.theme.text_color = text;
                     final_config.theme.background_color = bg;
+                    final_config.theme.secondary_bg_color = secondary;
                 }
                 SetConfigFields::SetThemeFields(SetConfigThemeFields::TextColor(r, g, b)) => {
                     final_config.theme.text_color = (r, g, b)
@@ -977,9 +978,10 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
                 ResetField::ThemeMode => {
                     tile.config.theme.theme_mode = default.theme.theme_mode;
                     let is_dark = crate::platform::macos::is_dark_mode();
-                    let (text, bg) = default.theme.theme_mode.presets(is_dark);
+                    let (text, bg, secondary) = default.theme.theme_mode.presets(is_dark);
                     tile.config.theme.text_color = text;
                     tile.config.theme.background_color = bg;
+                    tile.config.theme.secondary_bg_color = secondary;
                 }
                 ResetField::ShowScrollbar => {
                     tile.config.theme.show_scroll_bar = default.theme.show_scroll_bar
@@ -1049,9 +1051,10 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
         }
         Message::ThemeModeChanged(is_dark) => {
             if tile.config.theme.theme_mode == ThemeMode::System {
-                let (text, bg) = ThemeMode::System.presets(is_dark);
+                let (text, bg, secondary) = ThemeMode::System.presets(is_dark);
                 tile.config.theme.text_color = text;
                 tile.config.theme.background_color = bg;
+                tile.config.theme.secondary_bg_color = secondary;
                 tile.theme = tile.config.theme.clone().into();
             }
             Task::none()

--- a/src/app/tile/update.rs
+++ b/src/app/tile/update.rs
@@ -31,6 +31,7 @@ use crate::app::apps::AppCommand;
 use crate::app::default_settings;
 use crate::app::menubar::menu_builder;
 use crate::app::menubar::menu_icon;
+use crate::app::settings_window_settings;
 use crate::app::tile::AppIndex;
 use crate::app::{Message, Page, tile::Tile};
 use crate::autoupdate::download_latest_app;
@@ -121,12 +122,10 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
                 Task::none()
             }
         }
-
         Message::UpdateEvents => {
             tile.events = Event::get_events(tile.config.event_duration);
             Task::none()
         }
-
         Message::UriReceived(uri) => {
             let Ok(url) = Url::parse(&uri) else {
                 return Task::none();
@@ -149,7 +148,6 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
                 _ => Task::none(),
             }
         }
-
         Message::UpdateAvailable => {
             tile.update_available = true;
 
@@ -160,7 +158,6 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
             }
             Task::done(Message::ReloadConfig)
         }
-
         Message::SwitchMode(mode) => {
             if let Some(command) = tile.config.modes.get(mode.trim()) {
                 tile.current_mode = mode.clone();
@@ -174,7 +171,6 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
                 Task::none()
             }
         }
-
         Message::HideTrayIcon => {
             tile.tray_icon = None;
             tile.config.show_trayicon = false;
@@ -183,7 +179,6 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
             thread::spawn(move || fs::write(home + "/.config/rustcast/config.toml", confg_str));
             Task::none()
         }
-
         Message::SetSender(sender) => {
             tile.sender = Some(sender.clone());
             match global_handler(sender.clone(), tile.hotkeys.all_hotkeys()) {
@@ -198,7 +193,6 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
             }
             Task::none()
         }
-
         Message::ToggleAutoStartup(set_to) => {
             if set_to {
                 start_at_login();
@@ -209,7 +203,6 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
             }
             Task::none()
         }
-
         Message::EscKeyPressed(id) => {
             if !tile.query_lc.is_empty() {
                 return Task::batch([
@@ -220,9 +213,6 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
 
             match tile.page {
                 Page::Main => {}
-                Page::Settings => {
-                    return Task::done(Message::WriteConfig(true));
-                }
                 _ => {
                     return Task::done(Message::SwitchToPage(Page::Main));
                 }
@@ -249,13 +239,11 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
                 ])
             }
         }
-
         Message::ClearSearchQuery => {
             tile.query_lc = String::new();
             tile.query = String::new();
             Task::none()
         }
-
         Message::ChangeFocus(key, amount) => {
             let mut return_task = Task::none();
             for _ in 0..amount {
@@ -301,7 +289,6 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
                 let quantity = match tile.page {
                     Page::Main | Page::FileSearch | Page::ClipboardHistory => 66.5,
                     Page::EmojiSearch => 5.,
-                    Page::Settings => 0.,
                 };
 
                 let (wrapped_up, wrapped_down) = match &key {
@@ -331,7 +318,6 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
             }
             return_task
         }
-
         Message::ResizeWindow(id, height) => {
             info!("Resizing rustcast window");
             tile.height = height;
@@ -350,7 +336,6 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
 
             Task::none()
         }
-
         Message::SaveRanking => {
             tile.ranking = tile.options.get_rankings();
             let string_rep = toml::to_string(&tile.ranking).unwrap_or("".to_string());
@@ -359,10 +344,8 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
             fs::write(ranking_file_path, string_rep).ok();
             Task::none()
         }
-
         Message::OpenFocused => Task::done(Message::OpenResult(tile.focus_id)),
         Message::OpenResult(id) => open_result(tile, id as usize),
-
         Message::ReloadConfig => {
             info!("Reloading config");
             let new_config: Config = match toml::from_str(
@@ -426,7 +409,6 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
                 Task::done(Message::SetSender(tile.sender.clone().unwrap())),
             ])
         }
-
         Message::KeyPressed(shortcut) => {
             if let Some(cmd) = tile.hotkeys.shells.get(&shortcut) {
                 return Task::done(Message::RunFunction(Function::RunShellCommand(
@@ -475,20 +457,10 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
                 Task::none()
             }
         }
-
-        Message::OpenToSettings => {
-            tile.page = Page::Settings;
-            Task::batch([
-                Task::done(Message::OpenWindow),
-                open_window(((7 * 55) + 35 + DEFAULT_WINDOW_HEIGHT as usize) as f32),
-            ])
-        }
-
         Message::SwitchSettingsTab(tab) => {
             tile.settings_tab = tab;
             Task::none()
         }
-
         Message::SwitchToPage(page) => {
             let task = match &page {
                 Page::ClipboardHistory => {
@@ -503,13 +475,6 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
                         )
                     })
                 }
-                Page::Settings => window::latest().map(|x| {
-                    let id = x.unwrap();
-                    Message::ResizeWindow(
-                        id,
-                        ((7 * 55) + 35 + DEFAULT_WINDOW_HEIGHT as usize) as f32,
-                    )
-                }),
                 _ => Task::none(),
             };
 
@@ -530,7 +495,6 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
                 refresh_empty_main_query,
             ])
         }
-
         Message::RunFunction(command) => {
             if let Function::TileWindow(pos) = &command {
                 if let Some(pid) = tile.frontmost.as_ref().map(|a| a.processIdentifier()) {
@@ -541,10 +505,6 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
                 }
             }
             command.execute(&tile.config);
-            let page_task = match tile.page {
-                Page::Settings => Task::done(Message::SwitchToPage(Page::Main)),
-                _ => Task::none(),
-            };
 
             let return_focus_task = match &command {
                 Function::OpenApp(_) | Function::GoogleSearch(_) => Task::none(),
@@ -574,12 +534,10 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
             window::latest()
                 .map(|x| x.unwrap())
                 .map(Message::HideWindow)
-                .chain(page_task)
                 .chain(Task::done(Message::ClearSearchQuery))
                 .chain(return_focus_task)
                 .chain(paste_task)
         }
-
         Message::HideWindow(a) => {
             if tile.file_dialog_open {
                 return Task::none();
@@ -592,13 +550,11 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
 
             Task::batch([window::close(a), Task::done(Message::ClearSearchResults)])
         }
-
         Message::ReturnFocus => {
             info!("Restoring frontmost app");
             tile.restore_frontmost();
             Task::none()
         }
-
         Message::FocusTextInput(update_query_char) => {
             match update_query_char {
                 Move::Forwards(query_char) => {
@@ -619,7 +575,6 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
                     .map(move |x| Message::SearchQueryChanged(updated_query.clone(), x)),
             ])
         }
-
         Message::ToggleFavouriteApp(app_name) => {
             let ranking = match tile.options.by_name.get(&app_name) {
                 None => return Task::none(),
@@ -634,7 +589,6 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
             tile.options.set_ranking(&app_name, ranking);
             Task::none()
         }
-
         Message::UpdateApps => {
             let mut new_options = get_installed_apps(tile.config.theme.show_icons);
             new_options.extend(tile.config.shells.iter().map(|x| x.to_app()));
@@ -658,20 +612,22 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
 
             Task::none()
         }
-
         Message::ClearSearchResults => {
             tile.results = Vec::new();
             Task::none()
         }
         Message::WindowFocusChanged(wid, focused) => {
+            if Some(wid) == tile.settings_window {
+                return Task::none();
+            }
             tile.focused = focused;
+
             if !focused {
                 Task::done(Message::HideWindow(wid)).chain(Task::done(Message::ClearSearchQuery))
             } else {
                 Task::none()
             }
         }
-
         Message::EditClipboardHistory(action) => {
             if !tile.config.cbhist {
                 return Task::none();
@@ -721,12 +677,10 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
             }
             Task::none()
         }
-
         Message::SetFileSearchSender(sender) => {
             tile.file_search_sender = Some(sender);
             Task::none()
         }
-
         Message::FileSearchResult(apps) => {
             assert!(apps.len() <= 50, "Batch must not exceed 50 results.");
             if tile.page == Page::FileSearch {
@@ -745,14 +699,12 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
             }
             Task::none()
         }
-
         Message::FileSearchClear => {
             if tile.page == Page::FileSearch {
                 tile.results.clear();
             }
             Task::none()
         }
-
         Message::SearchQueryChanged(input, id) => {
             tile.focus_id = 0;
 
@@ -781,7 +733,6 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
                 execute_query(tile, id)
             }
         }
-
         Message::OpenFileDialog(action) => {
             tile.file_dialog_open = true;
             let home = std::env::var("HOME").unwrap_or("/".to_string());
@@ -848,7 +799,6 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
                 }
             }
         }
-
         Message::FileDialogResult(inner) => {
             tile.file_dialog_open = false;
             match inner {
@@ -856,7 +806,6 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
                 None => Task::none(),
             }
         }
-
         Message::SetConfig(config) => {
             let mut final_config = tile.config.clone();
             match config.clone() {
@@ -1009,7 +958,6 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
             tile.theme = tile.config.theme.clone().into();
             Task::none()
         }
-
         Message::ResetField(field) => {
             let default = Config::default();
             match field {
@@ -1059,7 +1007,6 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
             }
             Task::none()
         }
-
         Message::WriteConfig(page_switch) => {
             let config_file_path =
                 std::env::var("HOME").unwrap_or("".to_string()) + "/.config/rustcast/config.toml";
@@ -1092,17 +1039,14 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
                 },
             ])
         }
-
         Message::ClearClipboardHistory => {
             tile.clipboard_content.clear();
             Task::none()
         }
-
         Message::SimulatePaste(pid) => {
             crate::platform::simulate_paste(pid);
             Task::none()
         }
-
         Message::ThemeModeChanged(is_dark) => {
             if tile.config.theme.theme_mode == ThemeMode::System {
                 let (text, bg) = ThemeMode::System.presets(is_dark);
@@ -1112,7 +1056,6 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
             }
             Task::none()
         }
-
         Message::DebouncedSearch(id) => {
             // Only execute if this is still the most recent debounce timer
             if !tile.debouncer.is_ready() {
@@ -1121,6 +1064,16 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
 
             execute_query(tile, id)
         }
+        Message::OpenSettingsWindow => {
+            if let Some(id) = tile.settings_window {
+                window::gain_focus(id)
+            } else {
+                let (id, task) = window::open(settings_window_settings());
+                tile.settings_window = Some(id);
+                task.map(move |_| Message::SettingsWindowOpened(id))
+            }
+        }
+        Message::SettingsWindowOpened(_id) => Task::none(),
     }
 }
 
@@ -1212,13 +1165,8 @@ fn execute_query(tile: &mut Tile, id: Id) -> Task<Message> {
     let mut task = Task::none();
     let prev_size = tile.results.len();
 
-    match tile.page {
-        Page::ClipboardHistory | Page::Settings => {
-            if tile.query_lc != "main" {
-                return Task::none();
-            }
-        }
-        _ => {}
+    if tile.page == Page::ClipboardHistory && tile.query_lc != "main" {
+        return Task::none();
     }
 
     if tile.page == Page::Main && tile.query_lc.is_empty() {
@@ -1452,11 +1400,6 @@ mod tests {
                     )),
                     0,
                 ),
-                test_app(
-                    "message",
-                    AppCommand::Message(Message::SwitchToPage(Page::Settings)),
-                    0,
-                ),
                 test_app("display", AppCommand::Display, 0),
             ]),
             emoji_apps: AppIndex::empty(),
@@ -1486,6 +1429,7 @@ mod tests {
             file_dialog_open: false,
             settings_tab: crate::app::SettingsTab::General,
             debouncer: crate::debounce::Debouncer::new(10),
+            settings_window: None,
         }
     }
 
@@ -1521,10 +1465,6 @@ mod tests {
             classify_query_action(&Page::Main, "fav", "fav"),
             Some(QueryAction::ShowFavourites)
         );
-        assert_eq!(
-            classify_query_action(&Page::Settings, "main", "main"),
-            Some(QueryAction::SwitchToPage(Page::Main))
-        );
     }
 
     #[test]
@@ -1549,11 +1489,6 @@ mod tests {
             test_app(
                 "openable",
                 AppCommand::Function(Function::OpenApp("/Applications/Openable.app".to_string())),
-                0,
-            ),
-            test_app(
-                "message",
-                AppCommand::Message(Message::SwitchToPage(Page::Settings)),
                 0,
             ),
             test_app("display", AppCommand::Display, 0),

--- a/src/config.rs
+++ b/src/config.rs
@@ -105,21 +105,26 @@ impl Default for ThemeMode {
 
 impl ThemeMode {
     /// Return preset text and background colors for this mode.
-    pub fn presets(&self, is_system_dark: bool) -> ((f32, f32, f32), (f32, f32, f32)) {
+    pub fn presets(
+        &self,
+        is_system_dark: bool,
+    ) -> ((f32, f32, f32), (f32, f32, f32), (f32, f32, f32)) {
         match self {
             ThemeMode::Dark => (
                 (0.95, 0.95, 0.96), // light text
                 (0.0, 0.0, 0.0),    // dark background
+                (0.1, 0.1, 0.1),    // dark secondary background
             ),
             ThemeMode::Light => (
                 (0.05, 0.05, 0.05), // dark text
                 (0.95, 0.95, 0.96), // light background
+                (0.9, 0.9, 0.9),    // light secondary background
             ),
             ThemeMode::System => {
                 if is_system_dark {
-                    ((0.95, 0.95, 0.96), (0.0, 0.0, 0.0))
+                    ((0.95, 0.95, 0.96), (0.0, 0.0, 0.0), (0.1, 0.1, 0.1))
                 } else {
-                    ((0.05, 0.05, 0.05), (0.95, 0.95, 0.96))
+                    ((0.05, 0.05, 0.05), (0.95, 0.95, 0.96), (0.9, 0.9, 0.9))
                 }
             }
         }
@@ -132,6 +137,7 @@ impl ThemeMode {
 pub struct Theme {
     pub text_color: (f32, f32, f32),
     pub background_color: (f32, f32, f32),
+    pub secondary_bg_color: (f32, f32, f32),
     pub blur: bool,
     pub show_icons: bool,
     pub show_scroll_bar: bool,
@@ -141,10 +147,11 @@ pub struct Theme {
 
 impl Default for Theme {
     fn default() -> Self {
-        let (text, bg) = ThemeMode::Dark.presets(true);
+        let (text, bg, secondary) = ThemeMode::Dark.presets(true);
         Self {
             text_color: text,
             background_color: bg,
+            secondary_bg_color: secondary,
             blur: false,
             show_icons: true,
             show_scroll_bar: false,
@@ -206,6 +213,16 @@ impl Theme {
             r: self.background_color.0,
             g: self.background_color.1,
             b: self.background_color.2,
+            a: 0.,
+        }
+    }
+
+    /// Return the secondary background color in the theme config of type [`iced::Color`]
+    pub fn secondary_bg_color(&self) -> iced::Color {
+        iced::Color {
+            r: self.secondary_bg_color.0,
+            g: self.secondary_bg_color.1,
+            b: self.secondary_bg_color.2,
             a: 0.,
         }
     }

--- a/src/styles.rs
+++ b/src/styles.rs
@@ -2,7 +2,8 @@
 use crate::config::Theme as ConfigTheme;
 use iced::Shadow;
 use iced::border::Radius;
-use iced::widget::{button, checkbox, container, radio, scrollable, slider};
+use iced::widget::toggler::Status;
+use iced::widget::{button, checkbox, container, radio, scrollable, slider, toggler};
 use iced::{Background, Border, Color, widget::text_input};
 
 /// Helper: mix base color with white (simple “tint”)
@@ -332,16 +333,53 @@ pub fn settings_contents_container_style(theme: &ConfigTheme) -> container::Styl
     }
 }
 
-pub fn settings_checkbox_style(theme: &ConfigTheme) -> checkbox::Style {
-    checkbox::Style {
-        background: Background::Color(Color::TRANSPARENT),
-        icon_color: theme.text_color(1.),
-        border: iced::Border {
-            color: theme.text_color(1.),
-            width: 1.,
-            radius: Radius::new(2.),
+pub fn settings_toggle_style(status: toggler::Status) -> toggler::Style {
+    match status {
+        Status::Active { is_toggled } => toggler::Style {
+            background: if is_toggled {
+                Background::Color(Color::from_rgb8(52, 199, 89)) // iOS System Green
+            } else {
+                Background::Color(Color::from_rgb8(174, 174, 178)) // iOS Gray
+            },
+            background_border_width: 0.0,
+            background_border_color: Color::TRANSPARENT,
+            foreground: Background::Color(Color::WHITE),
+            foreground_border_width: 0.0,
+            foreground_border_color: Color::TRANSPARENT,
+            text_color: Some(Color::BLACK),
+            border_radius: None,
+            padding_ratio: 0.05,
         },
-        text_color: None,
+        Status::Hovered { is_toggled } => toggler::Style {
+            background: if is_toggled {
+                Background::Color(Color::from_rgb8(48, 183, 82)) // Slightly deeper green
+            } else {
+                Background::Color(Color::from_rgb8(218, 218, 219)) // Slightly darker track gray
+            },
+            background_border_width: 0.0,
+            background_border_color: Color::TRANSPARENT,
+            foreground: Background::Color(Color::WHITE),
+            foreground_border_width: 0.0,
+            foreground_border_color: Color::TRANSPARENT,
+            text_color: Some(Color::BLACK),
+            border_radius: None,
+            padding_ratio: 0.05,
+        },
+        Status::Disabled { is_toggled } => toggler::Style {
+            background: if is_toggled {
+                Background::Color(Color::from_rgb8(179, 238, 194)) // Desaturated translucent green
+            } else {
+                Background::Color(Color::from_rgb8(242, 242, 247)) // Very faint gray
+            },
+            background_border_width: 0.0,
+            background_border_color: Color::TRANSPARENT,
+            foreground: Background::Color(Color::from_rgb8(250, 250, 250)), // Off-white handle
+            foreground_border_width: 0.0,
+            foreground_border_color: Color::TRANSPARENT,
+            text_color: Some(Color::from_rgb8(174, 174, 178)), // iOS Gray
+            border_radius: None,
+            padding_ratio: 0.05,
+        },
     }
 }
 

--- a/src/styles.rs
+++ b/src/styles.rs
@@ -298,8 +298,25 @@ pub fn settings_tab_style(
     }
 }
 
-/// Clean container style for the settings panel (non-glass, flat).
-pub fn settings_container_style(theme: &ConfigTheme) -> container::Style {
+/// Clean container style for the tabs in the settings panel (non-glass, flat).
+pub fn settings_tabs_container_style(theme: &ConfigTheme) -> container::Style {
+    container::Style {
+        background: Some(Background::Color(with_alpha(
+            tint(theme.secondary_bg_color(), 0.04),
+            0.25,
+        ))),
+        border: Border {
+            color: theme.text_color(0.15),
+            width: 0.5,
+            radius: Radius::new(10),
+        },
+        text_color: Some(theme.text_color(1.0)),
+        ..Default::default()
+    }
+}
+
+/// Clean container style for the contents in settings panel (non-glass, flat).
+pub fn settings_contents_container_style(theme: &ConfigTheme) -> container::Style {
     container::Style {
         background: Some(Background::Color(with_alpha(
             tint(theme.bg_color(), 0.04),

--- a/src/styles.rs
+++ b/src/styles.rs
@@ -302,10 +302,7 @@ pub fn settings_tab_style(
 /// Clean container style for the tabs in the settings panel (non-glass, flat).
 pub fn settings_tabs_container_style(theme: &ConfigTheme) -> container::Style {
     container::Style {
-        background: Some(Background::Color(with_alpha(
-            tint(theme.secondary_bg_color(), 0.04),
-            0.25,
-        ))),
+        background: Some(Background::Color(settings_surface(theme.bg_color(), 0.12))),
         border: Border {
             color: theme.text_color(0.15),
             width: 0.5,
@@ -319,10 +316,7 @@ pub fn settings_tabs_container_style(theme: &ConfigTheme) -> container::Style {
 /// Clean container style for the contents in settings panel (non-glass, flat).
 pub fn settings_contents_container_style(theme: &ConfigTheme) -> container::Style {
     container::Style {
-        background: Some(Background::Color(with_alpha(
-            tint(theme.bg_color(), 0.04),
-            0.25,
-        ))),
+        background: Some(Background::Color(settings_surface(theme.bg_color(), 0.10))),
         border: Border {
             color: theme.text_color(0.15),
             width: 0.5,

--- a/src/styles.rs
+++ b/src/styles.rs
@@ -3,7 +3,7 @@ use crate::config::Theme as ConfigTheme;
 use iced::Shadow;
 use iced::border::Radius;
 use iced::widget::toggler::Status;
-use iced::widget::{button, checkbox, container, radio, scrollable, slider, toggler};
+use iced::widget::{button, container, radio, scrollable, slider, toggler};
 use iced::{Background, Border, Color, widget::text_input};
 
 /// Helper: mix base color with white (simple “tint”)

--- a/src/styles.rs
+++ b/src/styles.rs
@@ -407,6 +407,13 @@ pub fn glass_surface(base: Color, focused: bool) -> Color {
     with_alpha(tint(base, t), a)
 }
 
+/// The settings window is opaque, but `theme.bg_color()` has an alpha of 0 so it
+/// would let the window background bleed through. This returns a fully opaque,
+/// slightly tinted surface so panels read as distinct from the window background.
+pub fn settings_surface(base: Color, amount: f32) -> Color {
+    with_alpha(tint(base, amount), 1.0)
+}
+
 /// Helper fn for making a borders color look like its glassy
 pub fn glass_border(base_text: Color, focused: bool) -> Color {
     let a = if focused { 0.35 } else { 0.22 };


### PR DESCRIPTION
This PR is in regards to the conversation on discord of redesigning the settings page UI.

This redesign moves the settings UI to it's own window, changes layout and toggles to better match Apple design standards, and fully supports light mode. No functionality of the settings page was changed, only the layout.

AI disclosure: AI was used to help with thinking through layouts for the new design and was used to help understand how new windows are opened in the codebase. AI was not used to write code.


https://github.com/user-attachments/assets/6b1374f3-b302-47ed-844f-f5a0607a0d1f

