### PR TITLE
fix borders on launcher

### DIFF
--- a/src/app/tile/elm.rs
+++ b/src/app/tile/elm.rs
@@ -271,7 +271,7 @@ fn footer(theme: Theme, current_mode: String, text: String) -> Element<'static, 
             false,
         ))),
         border: iced::Border {
-            color: glass_border(theme.text_color(1.0), false),
+            color: glass_border(theme.bg_color(), false),
             width: 0.,
             radius: Radius::new(radius).top(0.0),
         },

--- a/src/styles.rs
+++ b/src/styles.rs
@@ -44,7 +44,7 @@ pub fn contents_style(theme: &ConfigTheme) -> container::Style {
         background: None,
         text_color: None,
         border: iced::Border {
-            color: theme.text_color(0.9),
+            color: theme.bg_color(),
             width: 0.4,
             radius: Radius::new(14.0),
         },
@@ -120,7 +120,7 @@ pub fn results_scrollbar_style(tile: &ConfigTheme) -> scrollable::Style {
             scroller: scrollable::Scroller {
                 background: Background::Color(tile.text_color(0.7)),
                 border: Border {
-                    color: tile.text_color(1.),
+                    color: tile.bg_color(),
                     width: 0.1,
                     radius: Radius::new(0),
                 },
@@ -159,7 +159,7 @@ pub fn result_row_container_style(tile: &ConfigTheme, focused: bool) -> containe
     container::Style {
         background: Some(Background::Color(glass_surface(tile.bg_color(), focused))),
         border: Border {
-            color: glass_border(tile.text_color(1.), focused),
+            color: glass_border(tile.bg_color(), focused),
             width: 0.,
             radius: Radius::new(0.0),
         },


### PR DESCRIPTION
This PR references a conversation in discord about the white borders and extra bump showing behind borders of the launcher.

These changes change the border color from text color to bg color.

No AI was used during this PR

Current UI is shown at the start of the below video, updated UI is shown following that with the new PR build.

https://github.com/user-attachments/assets/d64f66aa-071a-42a0-8c27-cea29f8de3ab


