### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| > 0.7.1 | :white_check_mark: |
+| < 0.7.0 | :x:                |
+
+## Reporting a Vulnerability
+
+Use this section to tell people how to report a vulnerability.
+
+Email [admin@rustcast.app](mailto:admin@rustcast.app) with the security vulnerability 
+you have found and we'll put it in the priority list.


### PR DESCRIPTION
It is vital for rustcast to have a security policy added to it to allow secure reporting of vulnerabilities.