### PR TITLE
Fix favourites persistence

### DIFF
--- a/src/app/tile.rs
+++ b/src/app/tile.rs
@@ -86,7 +86,7 @@ impl AppIndex {
 
     fn get_rankings(&self) -> HashMap<String, i32> {
         HashMap::from_iter(self.by_name.iter().filter_map(|(name, app)| {
-            if app.ranking > 0 {
+            if app.ranking != 0 {
                 Some((name.to_owned(), app.ranking.to_owned()))
             } else {
                 None
@@ -671,7 +671,7 @@ mod tests {
         index.set_ranking("notes", -1);
 
         assert_eq!(index.get_rankings().get("safari"), Some(&2));
-        assert_eq!(index.get_rankings().get("notes"), None);
+        assert_eq!(index.get_rankings().get("notes"), Some(&-1));
 
         let top_ranked = index.top_ranked(2);
         assert_eq!(top_ranked.len(), 2);


### PR DESCRIPTION
Resolves issue #289 

get_rankings was only getting items with a value above 0, all favs are stored as a -1. So when rustcast was quit and reopen the favs were not reloaded into the app and therefore not persisted to the user.

This small fix just changes > 0 to != 0 and fixes a test allowing favs to persist to the user


https://github.com/user-attachments/assets/2a5f35ea-739c-435d-8e87-e154dd7464e5

